### PR TITLE
Calling reset on an iterator will throw an exception according to C# spec

### DIFF
--- a/src/MoonSharp.Interpreter/Interop/PredefinedUserData/EnumerableWrapper.cs
+++ b/src/MoonSharp.Interpreter/Interop/PredefinedUserData/EnumerableWrapper.cs
@@ -9,6 +9,7 @@ namespace MoonSharp.Interpreter.Interop
 	internal class EnumerableWrapper : IUserDataType
 	{
 		IEnumerator m_Enumerator;
+		private IEnumerator m_RunningEnumerator;
 		Script m_Script;
 		DynValue m_Prev = DynValue.Nil;
 		bool m_HasTurnOnce = false;
@@ -17,14 +18,12 @@ namespace MoonSharp.Interpreter.Interop
 		{
 			m_Script = script;
 			m_Enumerator = enumerator;
+			m_RunningEnumerator = m_Enumerator;
 		}
 
 		public void Reset()
 		{
-			if (m_HasTurnOnce)
-				m_Enumerator.Reset();
-
-			m_HasTurnOnce = true;
+			m_RunningEnumerator = m_Enumerator;
 		}
 
 		private DynValue GetNext(DynValue prev)
@@ -32,9 +31,9 @@ namespace MoonSharp.Interpreter.Interop
 			if (prev.IsNil())
 				Reset();
 
-			while (m_Enumerator.MoveNext())
+			while (m_RunningEnumerator.MoveNext())
 			{
-				DynValue v = ClrToScriptConversions.ObjectToDynValue(m_Script, m_Enumerator.Current);
+				DynValue v = ClrToScriptConversions.ObjectToDynValue(m_Script, m_RunningEnumerator.Current);
 
 				if (!v.IsNil())
 					return v;
@@ -69,11 +68,11 @@ namespace MoonSharp.Interpreter.Interop
 
 				if (idx == "Current" || idx == "current")
 				{
-					return DynValue.FromObject(script, m_Enumerator.Current);
+					return DynValue.FromObject(script, m_RunningEnumerator.Current);
 				}
 				else if (idx == "MoveNext" || idx == "moveNext" || idx == "move_next")
 				{
-					return DynValue.NewCallback((ctx, args) => DynValue.NewBoolean(m_Enumerator.MoveNext()));
+					return DynValue.NewCallback((ctx, args) => DynValue.NewBoolean(m_RunningEnumerator.MoveNext()));
 				}
 				else if (idx == "Reset" || idx == "reset")
 				{


### PR DESCRIPTION
The currently existing code calls the Reset function on the IEnumerator interface.

According to the C# Specification the following however is true:

> Note that enumerator objects do not support the IEnumerator.Reset method. Invoking this method causes a System.NotSupportedException to be thrown.

(10.14.4 of the C# specification 5.0. [Download](https://www.microsoft.com/en-us/download/details.aspx?id=7029))

What this means is that any Iterator that follows the C# _requirements_ will throw an exception in this code. 

To resolve this issue I have cached the original enumerator, and created a separate running enumerator, that can yield next values. When it needs to be reset the cached enumerator is called again.