### PR TITLE
Fix value stack leak in ExecIterPrep

### DIFF
--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -506,6 +506,7 @@ namespace MoonSharp.Interpreter.Execution.VM
 					var = v.Tuple.Length >= 3 ? v.Tuple[2] : DynValue.Nil;
 
 					m_ValueStack.Push(DynValue.NewTuple(f, s, var));
+					return;
 				}
 				else if (f.Type == DataType.Table)
 				{
@@ -514,6 +515,7 @@ namespace MoonSharp.Interpreter.Execution.VM
 					if (callmeta == null || callmeta.IsNil())
 					{
 						m_ValueStack.Push(EnumerableWrapper.ConvertTable(f.Table));
+						return;
 					}
 				}
 			}


### PR DESCRIPTION
Have been reading through the source for a while, back and forth, and noticed in `MoonSharp.Interpreter.Execution.VM.Processor.ExecIterPrep()` that there are possibilities that it pushes multiple iterators to the value stack. Is this intentional?

This PR just adds two returns to not create multiple iterator tuples.

As I'm reading the code, it looks like a leak onto the value stack. I may be wrong! Code review required.