### PR TITLE
Metatable support for UserData

### DIFF
--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,0 +1,2 @@
+﻿# Default ignored files
+/.idea.moonsharp/.idea/workspace.xml

--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/UserDataMetatablesTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/UserDataMetatablesTests.cs
@@ -1,0 +1,142 @@
+﻿using NUnit.Framework;
+
+namespace MoonSharp.Interpreter.Tests.EndToEnd
+{
+    
+    [TestFixture]
+    public class UserDataMetatablesTests
+    {
+
+        class GenericUserDataTestClass
+        {
+
+            int a;
+            public int b = 7;
+            public int c = 11;
+
+            public int x = 100;
+            public int y = 150;
+            public int z = 200;
+
+            public void SetA(int a)
+            {
+                this.a = a;
+            }
+
+            public int GetA()
+            {
+                return a;
+            }
+
+            public string GetSome()
+            {
+                return "Some";
+            }
+
+            public string GetAnything()
+            {
+                return "Anything";
+            }
+
+        }
+
+        Script CreateTestEnvironment() {
+            Script s = new Script(CoreModules.Preset_Complete);
+            var obj = new GenericUserDataTestClass();
+            UserData.RegisterType<GenericUserDataTestClass>();
+            s.Globals.Set("o", UserData.Create(obj));
+            return s;
+        }
+
+        [Test]
+        public void UserDataMetatable_NewIndexOverride() {
+            var s = CreateTestEnvironment();
+
+            var code = @"
+                local backingTable = {}
+
+                debug.setmetatable(o, { __newindex = function(ud, k, v)
+                     backingTable[k] = table.concat({'ud = ', tostring(ud), ', k = ', k, ', v = ', v})
+                end })
+
+                local test = table.concat({'ud = ', tostring(o), ', k = a, v = 2'})
+
+                o.a = 2
+
+                return test == backingTable.a
+                ";
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.Boolean, result.Type);
+            Assert.AreEqual(DynValue.True, result);
+        }
+
+        [Test]
+        public void UserDataMetatable_IndexOverride() {
+            var s = CreateTestEnvironment();
+
+            var code = @"
+                local backingTable = { c = 12, d = 42 }
+
+                debug.setmetatable(o, { __index = function(ud, k) 
+                    return tostring(backingTable[k]) .. '!'
+                end })
+
+                return table.concat({'check ', tostring(o.b), ' ', tostring(o.c), ' ', tostring(o.d)})
+            ";
+
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 7 11 42!", result.String);
+        }
+
+        [Test]
+        public void UserDataMetatable_Table_Recursive() {
+            var s = CreateTestEnvironment();
+            
+            var code = @"
+                local t = { c = 12, d = 42, n = -100 }
+                local mt = { __index = t, m = 99, n = 199, o = 200 } 
+
+                debug.setmetatable(o, mt)
+
+                return table.concat({'check ',
+                     tostring(o.b), ' ', tostring(o.c), ' ', tostring(o.d), ' ',
+                     tostring(o.m), ' ', tostring(o.n), ' ', tostring(o.o)})
+            ";
+
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 7 11 42 nil -100 nil", result.String);
+        }
+
+        [Test]
+        public void UserDataMetatable_UserDataMethodsOverride() {
+            var s = CreateTestEnvironment();
+            
+            var code = @"
+                local t = {
+                    f = 999,
+                    GetSome = function() return 'squirrels' end,
+                    HaveFun = function() return 'so much fun wow' end
+                }
+                local mt = { __index = t } 
+
+                debug.setmetatable(o, mt)
+
+                o:SetA(3)
+
+                return table.concat({'check ',
+                     tostring(o.GetA()), ' ', tostring(o.GetSome()), ' ', tostring(o.GetAnything()), ' ', tostring(o.f), ' ', tostring(o.HaveFun())
+                })
+            ";
+
+            var result = s.DoString(code);
+
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 3 Some Anything 999 so much fun wow", result.String);
+        }
+    }
+}

--- a/src/MoonSharp.Interpreter/CoreLib/DebugModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/DebugModule.cs
@@ -86,6 +86,8 @@ namespace MoonSharp.Interpreter.CoreLib
 				return DynValue.NewTable(S.GetTypeMetatable(v.Type));
 			else if (v.Type == DataType.Table)
 				return DynValue.NewTable(v.Table.MetaTable);
+			else if (v.Type == DataType.UserData)
+				return DynValue.NewTable(v.UserData.MetaTable);
 			else
 				return DynValue.Nil;
 		}
@@ -102,6 +104,8 @@ namespace MoonSharp.Interpreter.CoreLib
 				S.SetTypeMetatable(v.Type, m);
 			else if (v.Type == DataType.Table)
 				v.Table.MetaTable = m;
+			else if (v.Type == DataType.UserData)
+				v.UserData.MetaTable = m;
 			else
 				throw new ScriptRuntimeException("cannot debug.setmetatable on type {0}", v.Type.ToErrorTypeString());
 

--- a/src/MoonSharp.Interpreter/DataTypes/CallbackArguments.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/CallbackArguments.cs
@@ -200,6 +200,15 @@ namespace MoonSharp.Interpreter
 					throw new ScriptRuntimeException("'tostring' must return a string to '{0}'", funcName);
 
 				return v.ToPrintString();
+			} else if ((this[argNum].Type == DataType.UserData) && (this[argNum].UserData.MetaTable != null) &&
+			           (this[argNum].UserData.MetaTable.RawGet("__tostring") != null))
+			{
+				var v = executionContext.GetScript().Call(this[argNum].UserData.MetaTable.RawGet("__tostring"), this[argNum]);
+
+				if (v.Type != DataType.String)
+					throw new ScriptRuntimeException("'tostring' must return a string to '{0}'", funcName);
+
+				return v.ToPrintString();
 			}
 			else
 			{

--- a/src/MoonSharp.Interpreter/DataTypes/UserData.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/UserData.cs
@@ -52,6 +52,20 @@ namespace MoonSharp.Interpreter
 			DefaultAccessMode = InteropAccessMode.LazyOptimized;
 		}
 
+		
+		
+		/// <summary>
+		/// Gets the meta-table associated with this instance.
+		/// </summary>
+		public Table MetaTable
+		{
+			get { return m_MetaTable; }
+			set { m_MetaTable = value; }
+		}
+		private Table m_MetaTable;
+		
+		
+		
 		/// <summary>
 		/// Registers a type for userdata interop
 		/// </summary>

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
@@ -9,6 +9,9 @@ namespace MoonSharp.Interpreter.Execution.VM
 			{
 				return value.Table.MetaTable;
 			}
+			else if (value.Type == DataType.UserData) {
+				return value.UserData.MetaTable;
+			}
 			else if (value.Type.CanHaveTypeMetatables())
 			{
 				return m_Script.GetTypeMetatable(value.Type);

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -1243,13 +1243,18 @@ namespace MoonSharp.Interpreter.Execution.VM
 				else if (obj.Type == DataType.UserData)
 				{
 					UserData ud = obj.UserData;
+					
+					h = GetMetamethodRaw(obj, "__newindex");
 
-					if (!ud.Descriptor.SetIndex(this.GetScript(), ud.Object, originalIdx, value, isNameIndex))
+					if (h == null || h.IsNil())
 					{
-						throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
-					}
+						if (!ud.Descriptor.SetIndex(this.GetScript(), ud.Object, originalIdx, value, isNameIndex))
+						{
+							throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						}
 
-					return instructionPtr;
+						return instructionPtr;
+					}
 				}
 				else
 				{
@@ -1330,11 +1335,17 @@ namespace MoonSharp.Interpreter.Execution.VM
 
 					if (v == null)
 					{
-						throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						h = GetMetamethodRaw(obj, "__index");
+						if (h == null || h.IsNil())
+						{
+							throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						}
 					}
-
-					m_ValueStack.Push(v.AsReadOnly());
-					return instructionPtr;
+					else
+					{
+						m_ValueStack.Push(v.AsReadOnly());
+						return instructionPtr;
+					}
 				}
 				else
 				{

--- a/src/MoonSharp.VsCodeDebugger/DebuggerLogic/VariableInspector.cs
+++ b/src/MoonSharp.VsCodeDebugger/DebuggerLogic/VariableInspector.cs
@@ -54,12 +54,22 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 					if (v.UserData.Descriptor != null)
 					{
 						variables.Add(new Variable("(descriptor)", v.UserData.Descriptor.Name));
-						variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString()));
+						if (v.UserData.MetaTable != null)
+						{
+							variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString() + ", has metatable"));
+						}
+						else
+						{
+							variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString()));
+						}
 					}
 					else
 					{
 						variables.Add(new Variable("(descriptor)", "null!"));
 					}
+					
+					if (v.UserData.MetaTable != null)
+						variables.Add(new Variable("(metatable #id)", v.UserData.MetaTable.ReferenceID.ToString()));
 
 					variables.Add(new Variable("(native object)", v.UserData.Object != null ? v.UserData.Object.ToString() : "(null)"));
 					break;

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Debugger/DebuggerLogic/VariableInspector.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Debugger/DebuggerLogic/VariableInspector.cs
@@ -54,12 +54,22 @@ namespace MoonSharp.VsCodeDebugger.DebuggerLogic
 					if (v.UserData.Descriptor != null)
 					{
 						variables.Add(new Variable("(descriptor)", v.UserData.Descriptor.Name));
-						variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString()));
+						if (v.UserData.MetaTable != null)
+						{
+							variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString() + ", has metatable"));
+						}
+						else
+						{
+							variables.Add(new Variable("(native type)", v.UserData.Descriptor.Type.ToString()));
+						}
 					}
 					else
 					{
 						variables.Add(new Variable("(descriptor)", "null!"));
 					}
+					
+					if (v.UserData.MetaTable != null)
+						variables.Add(new Variable("(metatable #id)", v.UserData.MetaTable.ReferenceID.ToString()));
 
 					variables.Add(new Variable("(native object)", v.UserData.Object != null ? v.UserData.Object.ToString() : "(null)"));
 					break;

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/CoreLib/DebugModule.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/CoreLib/DebugModule.cs
@@ -86,6 +86,8 @@ namespace MoonSharp.Interpreter.CoreLib
 				return DynValue.NewTable(S.GetTypeMetatable(v.Type));
 			else if (v.Type == DataType.Table)
 				return DynValue.NewTable(v.Table.MetaTable);
+			else if (v.Type == DataType.UserData)
+				return DynValue.NewTable(v.UserData.MetaTable);
 			else
 				return DynValue.Nil;
 		}
@@ -102,6 +104,8 @@ namespace MoonSharp.Interpreter.CoreLib
 				S.SetTypeMetatable(v.Type, m);
 			else if (v.Type == DataType.Table)
 				v.Table.MetaTable = m;
+			else if (v.Type == DataType.UserData)
+				v.UserData.MetaTable = m;
 			else
 				throw new ScriptRuntimeException("cannot debug.setmetatable on type {0}", v.Type.ToErrorTypeString());
 

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/DataTypes/CallbackArguments.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/DataTypes/CallbackArguments.cs
@@ -200,6 +200,15 @@ namespace MoonSharp.Interpreter
 					throw new ScriptRuntimeException("'tostring' must return a string to '{0}'", funcName);
 
 				return v.ToPrintString();
+			} else if ((this[argNum].Type == DataType.UserData) && (this[argNum].UserData.MetaTable != null) &&
+			           (this[argNum].UserData.MetaTable.RawGet("__tostring") != null))
+			{
+				var v = executionContext.GetScript().Call(this[argNum].UserData.MetaTable.RawGet("__tostring"), this[argNum]);
+
+				if (v.Type != DataType.String)
+					throw new ScriptRuntimeException("'tostring' must return a string to '{0}'", funcName);
+
+				return v.ToPrintString();
 			}
 			else
 			{

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/DataTypes/UserData.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/DataTypes/UserData.cs
@@ -52,6 +52,20 @@ namespace MoonSharp.Interpreter
 			DefaultAccessMode = InteropAccessMode.LazyOptimized;
 		}
 
+		
+		
+		/// <summary>
+		/// Gets the meta-table associated with this instance.
+		/// </summary>
+		public Table MetaTable
+		{
+			get { return m_MetaTable; }
+			set { m_MetaTable = value; }
+		}
+		private Table m_MetaTable;
+		
+		
+		
 		/// <summary>
 		/// Registers a type for userdata interop
 		/// </summary>

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
@@ -9,6 +9,9 @@ namespace MoonSharp.Interpreter.Execution.VM
 			{
 				return value.Table.MetaTable;
 			}
+			else if (value.Type == DataType.UserData) {
+				return value.UserData.MetaTable;
+			}
 			else if (value.Type.CanHaveTypeMetatables())
 			{
 				return m_Script.GetTypeMetatable(value.Type);

--- a/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/Unity/MoonSharp/Assets/Plugins/MoonSharp/Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -1243,13 +1243,18 @@ namespace MoonSharp.Interpreter.Execution.VM
 				else if (obj.Type == DataType.UserData)
 				{
 					UserData ud = obj.UserData;
+					
+					h = GetMetamethodRaw(obj, "__newindex");
 
-					if (!ud.Descriptor.SetIndex(this.GetScript(), ud.Object, originalIdx, value, isNameIndex))
+					if (h == null || h.IsNil())
 					{
-						throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
-					}
+						if (!ud.Descriptor.SetIndex(this.GetScript(), ud.Object, originalIdx, value, isNameIndex))
+						{
+							throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						}
 
-					return instructionPtr;
+						return instructionPtr;
+					}
 				}
 				else
 				{
@@ -1330,11 +1335,17 @@ namespace MoonSharp.Interpreter.Execution.VM
 
 					if (v == null)
 					{
-						throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						h = GetMetamethodRaw(obj, "__index");
+						if (h == null || h.IsNil())
+						{
+							throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+						}
 					}
-
-					m_ValueStack.Push(v.AsReadOnly());
-					return instructionPtr;
+					else
+					{
+						m_ValueStack.Push(v.AsReadOnly());
+						return instructionPtr;
+					}
 				}
 				else
 				{

--- a/src/Unity/MoonSharp/Assets/Tests/EndToEnd/SimpleTests.cs
+++ b/src/Unity/MoonSharp/Assets/Tests/EndToEnd/SimpleTests.cs
@@ -1016,7 +1016,7 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 		{
 			string script = @"function Allowed( )
 									for i = 1, 20 do
-  										return false
+										return false
 									end
 									return true
 								end
@@ -1032,7 +1032,7 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			string script = @"function Allowed( )
 									for i = 1, 20 do
 									if ( false ) or ( true and true ) or ( 7+i <= 9 and false ) then
-  										return false
+										return false
 									end
 									end
 									return true
@@ -1053,7 +1053,7 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 						function Allowed( )
 									for i = 1, 20 do
 									if ( t[1][3] ) or ( i <= 17 and t[1][1] ) or ( 7+i <= 9 and t[1][1] ) then
-  										return false
+										return false
 									end
 									end
 									return true

--- a/src/Unity/MoonSharp/Assets/Tests/EndToEnd/UserDataMetatablesTests.cs
+++ b/src/Unity/MoonSharp/Assets/Tests/EndToEnd/UserDataMetatablesTests.cs
@@ -1,0 +1,142 @@
+﻿using NUnit.Framework;
+
+namespace MoonSharp.Interpreter.Tests.EndToEnd
+{
+    
+    [TestFixture]
+    public class UserDataMetatablesTests
+    {
+
+        class GenericUserDataTestClass
+        {
+
+            int a;
+            public int b = 7;
+            public int c = 11;
+
+            public int x = 100;
+            public int y = 150;
+            public int z = 200;
+
+            public void SetA(int a)
+            {
+                this.a = a;
+            }
+
+            public int GetA()
+            {
+                return a;
+            }
+
+            public string GetSome()
+            {
+                return "Some";
+            }
+
+            public string GetAnything()
+            {
+                return "Anything";
+            }
+
+        }
+
+        Script CreateTestEnvironment() {
+            Script s = new Script(CoreModules.Preset_Complete);
+            var obj = new GenericUserDataTestClass();
+            UserData.RegisterType<GenericUserDataTestClass>();
+            s.Globals.Set("o", UserData.Create(obj));
+            return s;
+        }
+
+        [Test]
+        public void UserDataMetatable_NewIndexOverride() {
+            var s = CreateTestEnvironment();
+
+            var code = @"
+                local backingTable = {}
+
+                debug.setmetatable(o, { __newindex = function(ud, k, v)
+                     backingTable[k] = table.concat({'ud = ', tostring(ud), ', k = ', k, ', v = ', v})
+                end })
+
+                local test = table.concat({'ud = ', tostring(o), ', k = a, v = 2'})
+
+                o.a = 2
+
+                return test == backingTable.a
+                ";
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.Boolean, result.Type);
+            Assert.AreEqual(DynValue.True, result);
+        }
+
+        [Test]
+        public void UserDataMetatable_IndexOverride() {
+            var s = CreateTestEnvironment();
+
+            var code = @"
+                local backingTable = { c = 12, d = 42 }
+
+                debug.setmetatable(o, { __index = function(ud, k) 
+                    return tostring(backingTable[k]) .. '!'
+                end })
+
+                return table.concat({'check ', tostring(o.b), ' ', tostring(o.c), ' ', tostring(o.d)})
+            ";
+
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 7 11 42!", result.String);
+        }
+
+        [Test]
+        public void UserDataMetatable_Table_Recursive() {
+            var s = CreateTestEnvironment();
+            
+            var code = @"
+                local t = { c = 12, d = 42, n = -100 }
+                local mt = { __index = t, m = 99, n = 199, o = 200 } 
+
+                debug.setmetatable(o, mt)
+
+                return table.concat({'check ',
+                     tostring(o.b), ' ', tostring(o.c), ' ', tostring(o.d), ' ',
+                     tostring(o.m), ' ', tostring(o.n), ' ', tostring(o.o)})
+            ";
+
+            var result = s.DoString(code);
+            
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 7 11 42 nil -100 nil", result.String);
+        }
+
+        [Test]
+        public void UserDataMetatable_UserDataMethodsOverride() {
+            var s = CreateTestEnvironment();
+            
+            var code = @"
+                local t = {
+                    f = 999,
+                    GetSome = function() return 'squirrels' end,
+                    HaveFun = function() return 'so much fun wow' end
+                }
+                local mt = { __index = t } 
+
+                debug.setmetatable(o, mt)
+
+                o:SetA(3)
+
+                return table.concat({'check ',
+                     tostring(o.GetA()), ' ', tostring(o.GetSome()), ' ', tostring(o.GetAnything()), ' ', tostring(o.f), ' ', tostring(o.HaveFun())
+                })
+            ";
+
+            var result = s.DoString(code);
+
+            Assert.AreEqual(DataType.String, result.Type);
+            Assert.AreEqual("check 3 Some Anything 999 so much fun wow", result.String);
+        }
+    }
+}


### PR DESCRIPTION
This commit includes:

- Metatable support for `UserData`:
    - Directly assign Metatables with C#
    - Use the `debug.setmetatable()` and `debug.getmetatable()` functions from the `debug` module to access userdata metatables from Lua
- A few unit tests for the feature.