### PR TITLE
Fix json parse error which contains slash

### DIFF
--- a/src/MoonSharp.Interpreter.Tests/EndToEnd/JsonSerializationTests.cs
+++ b/src/MoonSharp.Interpreter.Tests/EndToEnd/JsonSerializationTests.cs
@@ -23,6 +23,9 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 			Assert.AreEqual(DataType.Table, t.Get("anObject").Type);
 			Assert.AreEqual(DataType.Table, t.Get("anArray").Type);
 
+			Assert.AreEqual(DataType.String, t.Get("slash").Type);
+			Assert.AreEqual("a/b", t.Get("slash").String);
+
 			Table o = t.Get("anObject").Table;
 
 			Assert.AreEqual(DataType.Number, o.Get("aNumber").Type);
@@ -72,7 +75,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 				'aString' : '2',
 				'anObject' : { 'aNumber' : 3, 'aString' : '4' },
 				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ],
-				'aNegativeNumber' : -9
+				'aNegativeNumber' : -9,
+				'slash' : 'a\/b'
 				}
 			".Replace('\'', '\"');
 
@@ -88,7 +92,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 				'aString' : '2',
 				'anObject' : { 'aNumber' : 3, 'aString' : '4' },
 				'anArray' : [ 5, '6', true, null, { 'aNumber' : 7, 'aString' : '8' } ],
-				'aNegativeNumber' : -9
+				'aNegativeNumber' : -9,
+				'slash' : 'a\/b'
 				}
 			".Replace('\'', '\"');
 
@@ -126,7 +131,8 @@ namespace MoonSharp.Interpreter.Tests.EndToEnd
 						aString = "8"
 					}
 				},
-				aNegativeNumber = -9
+				aNegativeNumber = -9,
+				slash = "a/b"
 			};
 
 

--- a/src/MoonSharp.Interpreter/Tree/Lexer/LexerUtils.cs
+++ b/src/MoonSharp.Interpreter/Tree/Lexer/LexerUtils.cs
@@ -171,6 +171,7 @@ namespace MoonSharp.Interpreter.Tree
 						else if (c == '\'') { sb.Append('\''); escape = false; zmode = false; }
 						else if (c == '[') { sb.Append('['); escape = false; zmode = false; }
 						else if (c == ']') { sb.Append(']'); escape = false; zmode = false; }
+						else if (c == '/') { sb.Append('/'); escape = false; zmode = false; }
 						else if (c == 'x') { hex = true; }
 						else if (c == 'u') { unicode_state = 1; }
 						else if (c == 'z') { zmode = true; escape = false; }

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Tree/Lexer/LexerUtils.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Tree/Lexer/LexerUtils.cs
@@ -171,6 +171,7 @@ namespace MoonSharp.Interpreter.Tree
 						else if (c == '\'') { sb.Append('\''); escape = false; zmode = false; }
 						else if (c == '[') { sb.Append('['); escape = false; zmode = false; }
 						else if (c == ']') { sb.Append(']'); escape = false; zmode = false; }
+						else if (c == '/') { sb.Append('/'); escape = false; zmode = false; }
 						else if (c == 'x') { hex = true; }
 						else if (c == 'u') { unicode_state = 1; }
 						else if (c == 'z') { zmode = true; escape = false; }


### PR DESCRIPTION
Fixed json parse error which contains escaped slash.

Sample code
```lua
local tbl = { name="a/b" }
-- slash is escaped
local s1 = json.serialize(tbl)
 -- parse error 
local s2 = json.parse(s2)
```