### PR TITLE
Fix OsTimeModule.clock returning nil at application start

### DIFF
--- a/src/MoonSharp.Interpreter/CoreLib/OsTimeModule.cs
+++ b/src/MoonSharp.Interpreter/CoreLib/OsTimeModule.cs
@@ -35,7 +35,9 @@ namespace MoonSharp.Interpreter.CoreLib
 		[MoonSharpModuleMethod]
 		public static DynValue clock(ScriptExecutionContext executionContext, CallbackArguments args)
 		{
-			return GetUnixTime(DateTime.UtcNow, Time0);
+			var t = GetUnixTime(DateTime.UtcNow, Time0);
+			if (t.IsNil()) return DynValue.NewNumber(0.0);
+			return t;
 		}
 
 		[MoonSharpModuleMethod]


### PR DESCRIPTION
os.clock should never be able to return `nil`, this patches it to return 0 in case of negative comparison.

Fixes a crash when running scimark.lua in the MoonSharp cli