### PR TITLE
Compiler: Evaluate constant expressions

### DIFF
--- a/src/MoonSharp.Interpreter/Tree/Expression_.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expression_.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using MoonSharp.Interpreter.Execution;
 using MoonSharp.Interpreter.Tree.Expressions;
+using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution.VM;
 
 namespace MoonSharp.Interpreter.Tree
 {
@@ -16,6 +19,18 @@ namespace MoonSharp.Interpreter.Tree
 		}
 
 		public abstract DynValue Eval(ScriptExecutionContext context);
+
+		public abstract bool EvalLiteral(out DynValue dv);
+
+		public void CompilePossibleLiteral(ByteCode bc)
+		{
+			if (EvalLiteral(out var dv))
+			{
+				if(dv == null) throw new NullReferenceException("Invalid literal: null");
+				bc.Emit_Literal(dv);
+			}
+			else Compile(bc);
+		}
 
 		public virtual SymbolRef FindDynamic(ScriptExecutionContext context)
 		{

--- a/src/MoonSharp.Interpreter/Tree/Expressions/AdjustmentExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/AdjustmentExpression.cs
@@ -1,4 +1,5 @@
-﻿using MoonSharp.Interpreter.Execution;
+﻿using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution;
 
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -22,6 +23,16 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		public override DynValue Eval(ScriptExecutionContext context)
 		{
 			return expression.Eval(context).ToScalar();
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			if (expression.EvalLiteral(out dv))
+			{
+				dv = dv.ToScalar();
+				return true;
+			}
+			return false;
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Expressions/DynamicExprExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/DynamicExprExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MoonSharp.Interpreter.DataStructs;
 using MoonSharp.Interpreter.Execution;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -18,6 +19,11 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		public override DynValue Eval(ScriptExecutionContext context)
 		{
 			return m_Exp.Eval(context);
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			throw new InvalidOperationException();
 		}
 
 		public override void Compile(Execution.VM.ByteCode bc)

--- a/src/MoonSharp.Interpreter/Tree/Expressions/ExprListExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/ExprListExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using MoonSharp.Interpreter.DataStructs;
 using MoonSharp.Interpreter.Execution;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -22,7 +23,7 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		public override void Compile(Execution.VM.ByteCode bc)
 		{
 			foreach (var exp in expressions)
-				exp.Compile(bc);
+				exp.CompilePossibleLiteral(bc);
 
 			if (expressions.Count > 1)
 				bc.Emit_MkTuple(expressions.Count);
@@ -34,6 +35,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 				return expressions[0].Eval(context);
 
 			return DynValue.Void;
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Expressions/FunctionCallExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/FunctionCallExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using MoonSharp.Interpreter.DataStructs;
 using MoonSharp.Interpreter.Debugging;
 using MoonSharp.Interpreter.Execution;
 
@@ -80,8 +81,9 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 				++argslen;
 			}
 
+			
 			for (int i = 0; i < m_Arguments.Count; i++)
-				m_Arguments[i].Compile(bc);
+				m_Arguments[i].CompilePossibleLiteral(bc);
 
 			if (!string.IsNullOrEmpty(m_Name))
 			{
@@ -91,6 +93,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 			{
 				bc.Emit_Call(argslen, m_DebugErr);
 			}
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 
 		public override DynValue Eval(ScriptExecutionContext context)

--- a/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using MoonSharp.Interpreter.DataStructs;
 using MoonSharp.Interpreter.Debugging;
 using MoonSharp.Interpreter.Execution;
 using MoonSharp.Interpreter.Execution.VM;
@@ -248,6 +249,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 			}
 
 			return CompileBody(bc, friendlyName);
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 
 

--- a/src/MoonSharp.Interpreter/Tree/Expressions/IndexExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/IndexExpression.cs
@@ -1,4 +1,5 @@
-﻿using MoonSharp.Interpreter.Execution;
+﻿using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution;
 using MoonSharp.Interpreter.Execution.VM;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -73,6 +74,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 			if (b.Type != DataType.Table) throw new DynamicExpressionException("Attempt to index non-table.");
 			else if (i.IsNilOrNan()) throw new DynamicExpressionException("Attempt to index with nil or nan key.");
 			return b.Table.Get(i) ?? DynValue.Nil;
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Expressions/LiteralExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/LiteralExpression.cs
@@ -1,4 +1,5 @@
-﻿using MoonSharp.Interpreter.Execution;
+﻿using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
 {
@@ -60,6 +61,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		public override DynValue Eval(ScriptExecutionContext context)
 		{
 			return m_Value;
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = m_Value;
+			return true;
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Expressions/SymbolRefExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/SymbolRefExpression.cs
@@ -1,4 +1,5 @@
-﻿using MoonSharp.Interpreter.Execution;
+﻿using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
 {
@@ -56,6 +57,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 		public override DynValue Eval(ScriptExecutionContext context)
 		{
 			return context.EvaluateSymbolByName(m_VarName);
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 
 		public override SymbolRef FindDynamic(ScriptExecutionContext context)

--- a/src/MoonSharp.Interpreter/Tree/Expressions/TableConstructor.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/TableConstructor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using MoonSharp.Interpreter.DataStructs;
 using MoonSharp.Interpreter.Execution;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -130,6 +131,12 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 			}
 
 			return tval;
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			return false;
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Expressions/UnaryOperatorExpression.cs
+++ b/src/MoonSharp.Interpreter/Tree/Expressions/UnaryOperatorExpression.cs
@@ -1,4 +1,6 @@
-﻿using MoonSharp.Interpreter.Execution;
+﻿using System;
+using MoonSharp.Interpreter.DataStructs;
+using MoonSharp.Interpreter.Execution;
 using MoonSharp.Interpreter.Execution.VM;
 
 namespace MoonSharp.Interpreter.Tree.Expressions
@@ -61,6 +63,32 @@ namespace MoonSharp.Interpreter.Tree.Expressions
 				default:
 					throw new DynamicExpressionException("Unexpected unary operator '{0}'", m_OpText);
 			}
+		}
+
+		public override bool EvalLiteral(out DynValue dv)
+		{
+			dv = null;
+			if (!m_Exp.EvalLiteral(out var v))
+			{
+				return false;
+			}
+			switch (m_OpText)
+			{
+				case "not":
+					dv = DynValue.NewBoolean(!v.CastToBool());
+					return true;
+				case "#":
+					return false;
+				case "-":
+					double? d = v.CastToNumber();
+					if (d.HasValue)
+					{
+						dv = DynValue.NewNumber(-d.Value);
+						return true;
+					}
+					break;
+			}
+			throw new Exception("Invalid literal evaluation");
 		}
 	}
 }

--- a/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/AssignmentStatement.cs
@@ -95,7 +95,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 			{
 				foreach (var exp in m_RValues)
 				{
-					exp.Compile(bc);
+					exp.CompilePossibleLiteral(bc);
 				}
 
 				for (int i = 0; i < m_LValues.Count; i++)

--- a/src/MoonSharp.Interpreter/Tree/Statements/ForLoopStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/ForLoopStatement.cs
@@ -60,11 +60,11 @@ namespace MoonSharp.Interpreter.Tree.Statements
 
 			bc.LoopTracker.Loops.Push(L);
 
-			m_End.Compile(bc);
+			m_End.CompilePossibleLiteral(bc);
 			bc.Emit_ToNum(3);
 			m_Step.Compile(bc);
 			bc.Emit_ToNum(2);
-			m_Start.Compile(bc);
+			m_Start.CompilePossibleLiteral(bc);
 			bc.Emit_ToNum(1);
 
 			int start = bc.GetJumpPointForNextInstruction();

--- a/src/MoonSharp.Interpreter/Tree/Statements/IfStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/IfStatement.cs
@@ -83,7 +83,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 					if (lastIfJmp != null)
 						lastIfJmp.NumVal = bc.GetJumpPointForNextInstruction();
 
-					ifblock.Exp.Compile(bc);
+					ifblock.Exp.CompilePossibleLiteral(bc);
 					lastIfJmp = bc.Emit_Jump(OpCode.Jf, -1);
 					bc.Emit_Enter(ifblock.StackFrame);
 					ifblock.Block.Compile(bc);

--- a/src/MoonSharp.Interpreter/Tree/Statements/ReturnStatement.cs
+++ b/src/MoonSharp.Interpreter/Tree/Statements/ReturnStatement.cs
@@ -51,7 +51,7 @@ namespace MoonSharp.Interpreter.Tree.Statements
 			{
 				if (m_Expression != null)
 				{
-					m_Expression.Compile(bc);
+					m_Expression.CompilePossibleLiteral(bc);
 					bc.Emit_Ret(1);
 				}
 				else


### PR DESCRIPTION
This updates Expressions to be able to be reduced to literals at compile time.

e.g. the expression `3 + 5 * 3` will become just `LITERAL 18` in bytecode.
