### PR TITLE
Auto Number->string conversion uses InvariantCulture

### DIFF
--- a/src/MoonSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
+++ b/src/MoonSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using MoonSharp.Interpreter.Compatibility;
 
 namespace MoonSharp.Interpreter.Interop.Converters
@@ -148,7 +149,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
                         			break;
                     			}
 					if (stringSubType != StringConversions.StringSubtype.None)
-						str = value.Number.ToString();
+						str = value.Number.ToString(CultureInfo.InvariantCulture);
 					break;
 				case DataType.String:
 					if (stringSubType != StringConversions.StringSubtype.None)

--- a/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Interop/Converters/ScriptToClrConversions.cs
+++ b/src/MoonSharp.Interpreter/_Projects/MoonSharp.Interpreter.netcore/src/Interop/Converters/ScriptToClrConversions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization; 
 using MoonSharp.Interpreter.Compatibility;
 
 namespace MoonSharp.Interpreter.Interop.Converters
@@ -143,7 +144,7 @@ namespace MoonSharp.Interpreter.Interop.Converters
 					if (NumericConversions.NumericTypes.Contains(desiredType))
 						return NumericConversions.DoubleToType(desiredType, value.Number);
 					if (stringSubType != StringConversions.StringSubtype.None)
-						str = value.Number.ToString();
+						str = value.Number.ToString(CultureInfo.InvariantCulture);
 					break;
 				case DataType.String:
 					if (stringSubType != StringConversions.StringSubtype.None)


### PR DESCRIPTION
It does use invariant culture in tostring() and DynValue.ToString() for example, so this is an inconsistency
This has caused bugs for us, since some locales use "," for the decimal seperator instead of "."