### PR TITLE
Added Coroutine recycling for Mono

### DIFF
--- a/src/MoonSharp.Interpreter/DataStructs/FastStack.cs
+++ b/src/MoonSharp.Interpreter/DataStructs/FastStack.cs
@@ -93,7 +93,7 @@ namespace MoonSharp.Interpreter.DataStructs
 
 		public void ClearUsed()
 		{
-			Array.Clear(m_Storage, 0, m_HeadIdx+1);
+			Array.Clear(m_Storage, 0, m_HeadIdx);
 			m_HeadIdx = 0;
 		}
 

--- a/src/MoonSharp.Interpreter/DataStructs/FastStack.cs
+++ b/src/MoonSharp.Interpreter/DataStructs/FastStack.cs
@@ -91,6 +91,12 @@ namespace MoonSharp.Interpreter.DataStructs
 			m_HeadIdx = 0;
 		}
 
+		public void ClearUsed()
+		{
+			Array.Clear(m_Storage, 0, m_HeadIdx+1);
+			m_HeadIdx = 0;
+		}
+
 		public int Count
 		{
 			get { return m_HeadIdx; }

--- a/src/MoonSharp.Interpreter/DataTypes/Coroutine.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/Coroutine.cs
@@ -27,7 +27,11 @@ namespace MoonSharp.Interpreter
 			/// <summary>
 			/// A CLR callback assigned to a coroutine and already executed.
 			/// </summary>
-			ClrCallbackDead
+			ClrCallbackDead,
+			/// <summary>
+			/// A recycled coroutine
+			/// </summary>
+			Recycled
 		}
 
 		/// <summary>
@@ -64,6 +68,7 @@ namespace MoonSharp.Interpreter
 
 		internal DynValue Recycle(Processor mainProcessor, Closure closure)
 		{
+			Type = CoroutineType.Recycled;
 			return m_Processor.Coroutine_Recycle(mainProcessor, closure);
 		}
 

--- a/src/MoonSharp.Interpreter/DataTypes/Coroutine.cs
+++ b/src/MoonSharp.Interpreter/DataTypes/Coroutine.cs
@@ -62,6 +62,10 @@ namespace MoonSharp.Interpreter
 			Type = CoroutineType.ClrCallbackDead;
 		}
 
+		internal DynValue Recycle(Processor mainProcessor, Closure closure)
+		{
+			return m_Processor.Coroutine_Recycle(mainProcessor, closure);
+		}
 
 		/// <summary>
 		/// Gets this coroutine as a typed enumerable which can be looped over for resuming.

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor.cs
@@ -8,10 +8,12 @@ namespace MoonSharp.Interpreter.Execution.VM
 {
 	sealed partial class Processor
 	{
+		const int STACK_SIZE = 131072;
+
 		ByteCode m_RootChunk;
 
-		FastStack<DynValue> m_ValueStack = new FastStack<DynValue>(131072);
-		FastStack<CallStackItem> m_ExecutionStack = new FastStack<CallStackItem>(131072);
+		FastStack<DynValue> m_ValueStack;
+		FastStack<CallStackItem> m_ExecutionStack;
 		List<Processor> m_CoroutinesStack;
 
 		Table m_GlobalTable;
@@ -22,8 +24,11 @@ namespace MoonSharp.Interpreter.Execution.VM
 		int m_SavedInstructionPtr = -1;
 		DebugContext m_Debug;
 
+
 		public Processor(Script script, Table globalContext, ByteCode byteCode)
 		{
+			m_ValueStack = new FastStack<DynValue>(STACK_SIZE);
+			m_ExecutionStack = new FastStack<CallStackItem>(STACK_SIZE);
 			m_CoroutinesStack = new List<Processor>();
 
 			m_Debug = new DebugContext();
@@ -36,6 +41,8 @@ namespace MoonSharp.Interpreter.Execution.VM
 
 		private Processor(Processor parentProcessor)
 		{
+			m_ValueStack = new FastStack<DynValue>(STACK_SIZE);
+			m_ExecutionStack = new FastStack<CallStackItem>(STACK_SIZE);
 			m_Debug = parentProcessor.m_Debug;
 			m_RootChunk = parentProcessor.m_RootChunk;
 			m_GlobalTable = parentProcessor.m_GlobalTable;
@@ -44,7 +51,19 @@ namespace MoonSharp.Interpreter.Execution.VM
 			m_State = CoroutineState.NotStarted;
 		}
 
+		//Takes the value and execution stack from recycleProcessor
+		internal Processor(Processor parentProcessor, Processor recycleProcessor)
+		{
+			m_ValueStack = recycleProcessor.m_ValueStack;
+			m_ExecutionStack = recycleProcessor.m_ExecutionStack;
 
+			m_Debug = parentProcessor.m_Debug;
+			m_RootChunk = parentProcessor.m_RootChunk;
+			m_GlobalTable = parentProcessor.m_GlobalTable;
+			m_Script = parentProcessor.m_Script;
+			m_Parent = parentProcessor;
+			m_State = CoroutineState.NotStarted;
+		}
 
 		public DynValue Call(DynValue function, DynValue[] args)
 		{

--- a/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_Coroutines.cs
+++ b/src/MoonSharp.Interpreter/Execution/VM/Processor/Processor_Coroutines.cs
@@ -19,6 +19,22 @@ namespace MoonSharp.Interpreter.Execution.VM
 			return DynValue.NewCoroutine(new Coroutine(P));
 		}
 
+		public DynValue Coroutine_Recycle(Processor mainProcessor, Closure closure)
+		{
+			// Clear the used parts of the stacks to prep for reuse
+			this.m_ValueStack.ClearUsed();
+			this.m_ExecutionStack.ClearUsed();
+
+			// Create a new processor instance, recycling this one
+			Processor P = new Processor(mainProcessor, this);
+
+			// Put the closure as first value on the stack, for future reference
+			P.m_ValueStack.Push(DynValue.NewClosure(closure));
+
+			// Return the coroutine handle
+			return DynValue.NewCoroutine(new Coroutine(P));
+		}
+
 		public CoroutineState State { get { return m_State; } }
 		public Coroutine AssociatedCoroutine { get; set; }
 

--- a/src/MoonSharp.Interpreter/Script.cs
+++ b/src/MoonSharp.Interpreter/Script.cs
@@ -546,6 +546,29 @@ namespace MoonSharp.Interpreter
 		}
 
 		/// <summary>
+		/// Creates a new coroutine, recycling buffers from a dead coroutine to skip slower buffer creation in Mono.
+		/// </summary>
+		/// <param name="coroutine">The <see cref="Coroutine"/> to recycle. This coroutine's state must be <see cref="CoroutineState.Dead"/></param>
+		/// <param name="function">The function</param>
+		/// <returns>
+		/// The new coroutine handle.
+		/// </returns>
+		public DynValue RecycleCoroutine(Coroutine coroutine, DynValue function)
+		{
+			this.CheckScriptOwnership(coroutine);
+			this.CheckScriptOwnership(function);
+
+			if (coroutine == null || coroutine.Type != Coroutine.CoroutineType.Coroutine)
+				throw new InvalidOperationException("coroutine is not CoroutineType.Coroutine");
+			if (function == null || function.Type != DataType.Function)
+				throw new InvalidOperationException("function is not DataType.Function");
+			if (coroutine.State != CoroutineState.Dead)
+				throw new InvalidOperationException("coroutine's state must be CoroutineState.Dead to recycle");
+
+			return coroutine.Recycle(m_MainProcessor, function.Function);
+		}
+
+		/// <summary>
 		/// Creates a coroutine pointing at the specified function.
 		/// </summary>
 		/// <param name="function">The function.</param>


### PR DESCRIPTION
When creating Coroutines with `Script.CreateCoroutine`, the creation of the `FastStack`s in the Coroutine's backing `Processor`  is very slow, *specifically* when running under Mono (Unity).
It is slow enough to be a large problem for my use cases, where I have a lot of non-clr coroutines that are frequently recreated.

I have added a function `Script.RecycleCoroutine` that greatly speeds up coroutine creation by clearing and reusing the `m_ValueStack` and `m_ExecutionStack` `FastStack`s from a dead coroutine's `Processor` instance instead.
In the scenario where you have coroutines that you want to re-create in Mono/Unity, this function is up to hundreds of times faster than using `Script.CreateCoroutine`.
It is slower than using `ScriptCreateCoroutine` when running under .Net Framework, so this is a Mono-specific benefit.